### PR TITLE
feat: allow liking art thumbnails

### DIFF
--- a/feeling-art-finder/src/ArtCard.jsx
+++ b/feeling-art-finder/src/ArtCard.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+export default function ArtCard({ item, liked, onToggle }) {
+  return (
+    <div className="card">
+      <button
+        className={`like-btn${liked ? ' liked' : ''}`}
+        onClick={e => {
+          e.preventDefault()
+          e.stopPropagation()
+          onToggle(item)
+        }}
+        aria-label={liked ? 'Unlike art' : 'Like art'}
+      >
+        {liked ? '♥' : '♡'}
+      </button>
+      <a href={item.url} target="_blank" rel="noreferrer">
+        <img src={item.img} alt={`${item.title} by ${item.artist}`} loading="lazy" />
+        <div className="meta">
+          <h3>{item.title}</h3>
+          <p>
+            {item.artist}
+            {item.date ? `, ${item.date}` : ''}
+          </p>
+          <p className="medium">{item.medium}</p>
+        </div>
+      </a>
+    </div>
+  )
+}

--- a/feeling-art-finder/src/styles.css
+++ b/feeling-art-finder/src/styles.css
@@ -13,9 +13,12 @@ header h1 { margin: 0; font-size: 40px; letter-spacing: .4px; }
 .hint { color: var(--muted); margin: 6px 0 18px; }
 .error { color: #ff9aa2; }
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 14px; }
-.card { display: block; background: var(--card); border: 1px solid #1f2430; border-radius: 16px; overflow: hidden; text-decoration: none; color: inherit; transition: transform .15s ease, border-color .15s ease; }
+.card { position: relative; background: var(--card); border: 1px solid #1f2430; border-radius: 16px; overflow: hidden; transition: transform .15s ease, border-color .15s ease; }
 .card:hover { transform: translateY(-2px); border-color: #2e3748; }
+.card a { display: block; text-decoration: none; color: inherit; }
 .card img { width: 100%; height: 220px; object-fit: cover; background: #0f1117; }
+.like-btn { position: absolute; top: 8px; right: 8px; background: rgba(0,0,0,.5); border: none; color: var(--ink); width: 32px; height: 32px; border-radius: 50%; cursor: pointer; font-size: 16px; line-height: 1; display: flex; align-items: center; justify-content: center; }
+.like-btn.liked { color: var(--accent); }
 .meta { padding: 10px 12px; }
 .meta h3 { margin: 0 0 6px; font-size: 15px; line-height: 1.3; }
 .meta p { margin: 0; color: var(--muted); font-size: 13px; }


### PR DESCRIPTION
## Summary
- add reusable ArtCard component with like button
- persist liked artworks in localStorage and show revisitable gallery
- style cards to support like overlay

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8db0c8e4c8330b23b4dcd05040e4b