### PR TITLE
Add likes tab to view saved artwork

### DIFF
--- a/feeling-art-finder/src/App.jsx
+++ b/feeling-art-finder/src/App.jsx
@@ -190,6 +190,7 @@ export default function App() {
     const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('likes') : null
     return saved ? JSON.parse(saved) : []
   })
+  const [tab, setTab] = useState('search')
 
   useEffect(() => {
     if (typeof localStorage !== 'undefined') {
@@ -246,50 +247,73 @@ export default function App() {
       <header>
         <h1>Feeling → Art</h1>
         <p className="sub">Type how you feel. We’ll fetch artwork that matches the vibe.</p>
+        <nav className="tabs">
+          <button
+            className={tab === 'search' ? 'active' : ''}
+            onClick={() => setTab('search')}
+            type="button"
+          >
+            Search
+          </button>
+          <button
+            className={tab === 'likes' ? 'active' : ''}
+            onClick={() => setTab('likes')}
+            type="button"
+          >
+            Likes ({likes.length})
+          </button>
+        </nav>
       </header>
 
-      <form onSubmit={handleSearch} className="bar">
-        <input
-          value={text}
-          onChange={e => setText(e.target.value)}
-          placeholder="e.g., I feel calm but a little nostalgic"
-          aria-label="Describe your feelings"
-        />
-        <button disabled={!text.trim() || loading}>{loading ? 'Searching…' : 'Find art'}</button>
-      </form>
-
-      {suggestedTerms.length > 0 && (
-        <div className="chips" aria-live="polite">
-          Suggested terms: {suggestedTerms.map(t => <span key={t} className="chip">{t}</span>)}
-        </div>
-      )}
-
-      {query && <p className="hint">Searching The Met and Art Institute of Chicago for: <strong>{query}</strong></p>}
-      {error && <p className="error">{error}</p>}
-
-      <section className="grid">
-        {results.map(item => (
-          <ArtCard
-            key={item.id}
-            item={item}
-            liked={likes.some(i => i.id === item.id)}
-            onToggle={toggleLike}
-          />
-        ))}
-      </section>
-
-      {!loading && results.length === 0 && query && (
-        <p className="empty">No matches. Try different words like “landscape”, “sunlight”, or “nocturne”.</p>
-      )}
-
-      {likes.length > 0 && (
+      {tab === 'search' && (
         <>
-          <h2>Liked Art</h2>
+          <form onSubmit={handleSearch} className="bar">
+            <input
+              value={text}
+              onChange={e => setText(e.target.value)}
+              placeholder="e.g., I feel calm but a little nostalgic"
+              aria-label="Describe your feelings"
+            />
+            <button disabled={!text.trim() || loading}>{loading ? 'Searching…' : 'Find art'}</button>
+          </form>
+
+          {suggestedTerms.length > 0 && (
+            <div className="chips" aria-live="polite">
+              Suggested terms: {suggestedTerms.map(t => <span key={t} className="chip">{t}</span>)}
+            </div>
+          )}
+
+          {query && <p className="hint">Searching The Met and Art Institute of Chicago for: <strong>{query}</strong></p>}
+          {error && <p className="error">{error}</p>}
+
           <section className="grid">
-            {likes.map(item => (
-              <ArtCard key={item.id} item={item} liked onToggle={toggleLike} />
+            {results.map(item => (
+              <ArtCard
+                key={item.id}
+                item={item}
+                liked={likes.some(i => i.id === item.id)}
+                onToggle={toggleLike}
+              />
             ))}
           </section>
+
+          {!loading && results.length === 0 && query && (
+            <p className="empty">No matches. Try different words like “landscape”, “sunlight”, or “nocturne”.</p>
+          )}
+        </>
+      )}
+
+      {tab === 'likes' && (
+        <>
+          {likes.length === 0 ? (
+            <p className="empty">No liked art yet.</p>
+          ) : (
+            <section className="grid">
+              {likes.map(item => (
+                <ArtCard key={item.id} item={item} liked onToggle={toggleLike} />
+              ))}
+            </section>
+          )}
         </>
       )}
 

--- a/feeling-art-finder/src/styles.css
+++ b/feeling-art-finder/src/styles.css
@@ -5,6 +5,9 @@ body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI
 .wrap { max-width: 1000px; margin: 40px auto; padding: 0 20px; }
 header h1 { margin: 0; font-size: 40px; letter-spacing: .4px; }
 .sub { color: var(--muted); margin-top: 6px; }
+.tabs { display: flex; gap: 16px; margin-top: 20px; }
+.tabs button { background: none; border: none; color: var(--muted); cursor: pointer; padding: 8px 0; font-size: 16px; border-bottom: 2px solid transparent; }
+.tabs button.active { color: var(--accent); border-color: var(--accent); }
 .bar { display: flex; gap: 10px; margin: 22px 0; }
 .bar input { flex: 1; padding: 14px 16px; border-radius: 12px; border: 1px solid #2a2f3a; background: var(--card); color: var(--ink); }
 .bar button { padding: 14px 18px; border-radius: 12px; border: 1px solid transparent; background: var(--accent); color: #0b1020; font-weight: 700; cursor: pointer; }


### PR DESCRIPTION
## Summary
- add navigation tabs to switch between search and liked art
- display saved artwork in dedicated Likes tab with empty state
- style tab buttons for active state highlight

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9cd5769e08330b966b1b8afd9e452